### PR TITLE
fix: update schema creation script with changes to the cli

### DIFF
--- a/scripts/build_schemas
+++ b/scripts/build_schemas
@@ -1,8 +1,6 @@
 #!/bin/bash
 schemas_output_dir="$1"
 
-hamlet entrance -i mock -p aws -p awstest -p azure -p azuretest invoke-entrance -e schema -u component -o "$schemas_output_dir"
-hamlet entrance -i mock -p aws -p awstest -p azure -p azuretest invoke-entrance -e schema -u reference -o  "$schemas_output_dir"
-hamlet entrance -i mock -p aws -p awstest -p azure -p azuretest invoke-entrance -e schema -u metaparameter -o "$schemas_output_dir"
+hamlet schemas -i mock -p shared -p sharedtest -p aws -p awstest -p azure -p azuretest create-schemas -o "$schemas_output_dir"
 # Remove Generated Contracts
 rm "${schemas_output_dir}"/schema-*-generation-contract.json


### PR DESCRIPTION
Correct schema creation script to use the latest Hamlet CLI commands.

Now creates all schemas in one command using `hamlet schema create-schemas`