### PR TITLE
feat: clean schema output directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   properties_file_path:
     description: Path to a properties file containing environment variables
     default: ""
+  refresh_output_dir:
+    description: Delete content in the output directory before other tasks
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -17,3 +20,4 @@ runs:
     - ${{ inputs.task_build_schemas }}
     - ${{ inputs.task_build_schemas_output }}
     - ${{ inputs.properties_file_path }}
+    - ${{ inputs.refresh_output_dir }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,11 @@
 build_schemas="$1"
 schemas_output_dir="$2"
 properties_file_path="$3"
+refresh_output_dir="$4"
 
 # Set the environment variables file
 # Includes search for properties file
 /scripts/set_env "${properties_file_path}" "GITHUB_ENV"
 
 # Run Tasks
-[ "$build_schemas" == "true" ] && /scripts/build_schemas "$schemas_output_dir"
+[ "$build_schemas" == "true" ] && /scripts/build_schemas "$schemas_output_dir" "$refresh_output_dir"

--- a/scripts/build_schemas
+++ b/scripts/build_schemas
@@ -1,5 +1,17 @@
 #!/bin/bash
-schemas_output_dir="$1"
+schemas_output_dir="$1"; shift
+refresh_output_dir="$1"; shift
+
+DEFAULT_REFRESH_OUTPUT_DIR="false"
+REFRESH_OUTPUT_DIR="${refresh_output_dir:-${DEFAULT_REFRESH_OUTPUT_DIR}}"
+
+# delete contents within the output directory prior to building schemas
+# this will clear out any old or incorrect schemas
+if [[ ${REFRESH_OUTPUT_DIR} == "true" ]]; then
+    echo "::warning Clearing the Output Directory of old content."
+    echo "::warning     Output Dir: ${schemas_output_dir}"
+    rm -rf "${schemas_output_dir:?}/*"
+fi
 
 hamlet -i mock -p shared -p aws -p azure schema create-schemas -o "$schemas_output_dir"
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Adds capability to the Action to "clean" (delete) the output directory prior to performing schema build.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Schemas were for a time being created under an incorrect naming convention. When this was fixed, the old schemas under the correct name remained on the docs site, and could be accessed.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
N/a

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [ ] once merged into master, this needs to be tagged and pushed as per the README